### PR TITLE
changed attribute in (required) tag to no longer hide dialog titlebar…

### DIFF
--- a/Windows XP Royale/metacity-1/metacity-theme-3.xml
+++ b/Windows XP Royale/metacity-1/metacity-theme-3.xml
@@ -38,7 +38,7 @@ Frame Dimensions and stuff
   <distance name="bottom_height" value="3"/>
 </frame_geometry>
 
-<frame_geometry name="nobuttons" hide_buttons="true" parent="dialog">
+<frame_geometry name="nobuttons" hide_buttons="false" parent="dialog">
 </frame_geometry>
 
 <frame_geometry name="maximized" parent="normal" rounded_top_left="false" rounded_top_right="false">


### PR DESCRIPTION
… buttons.

The Royale theme does not seem to load without the `<frame_geometry name="nobuttons" hide_buttons="false" parent="dialog">
</frame_geometry>` tag, but changing the hide_buttons attribute from true to false is enough to get the buttons back.