### PR TITLE
No14  add/edit css syles for font forecolor in cal appl

### DIFF
--- a/Windows XP Royale/cinnamon/cinnamon.css
+++ b/Windows XP Royale/cinnamon/cinnamon.css
@@ -269,7 +269,7 @@ StScrollBar StButton#vhandle:hover {
 #panelRight {
     border-image: url('panel-right.png') 7 0 0 0;
     color: #000;
-    text-shadow: white 0px 1px 1px;
+    text-shadow: #444 0px 1px 1px;
 }
 
 #panelLeft .applet-box:first-child {
@@ -1962,6 +1962,12 @@ border-radius: 1px;
 
 .applet-label:not(:first-child) {
     font-weight: normal;
+}
+
+#panelRight .applet-label {
+    color: #6666cc;
+    font-weight: bold;
+    text-shadow: #000000;
 }
 
 .applet-label:hover,


### PR DESCRIPTION
In cinnamon.css, in Royale theme, alter calendar applet font forecolor and shadow to stand out from panel background. 

change at line 272:
#panelRight { border-image: url('panel-right.png') 7 0 0 0; color: #000; text-shadow: #444/*white*/ 0px 1px 1px; }

insert at line 1966:
#panelRight .applet-label { color: #6666cc; font-weight: bold; text-shadow: #000000; }