### PR TITLE
feat: fix window grouped list foreground in cinnamon (Homestead)

### DIFF
--- a/Windows XP Homestead/cinnamon/cinnamon.css
+++ b/Windows XP Homestead/cinnamon/cinnamon.css
@@ -1697,19 +1697,23 @@ height of the table to be ICON_SIZE + IMAGE_SIZE + spacing-rows = 24 + 125 + 10 
   padding: 1px;
   text-shadow: none;
   transition-duration: 100;
+  color: black;
 }
 
 .window-list-item-box:active,
 .window-list-item-box:checked,
 .window-list-item-box:focus    {
   border-image: url('active.png') 5;
-  color: white;
   /*    text-shadow: black 1px 1px; */
 }
 
 
 .window-list-item-box:hover  {
   border-image: url('hover.png') 5;
+}
+
+.window-list-item-box:focus {
+  color: #ffffff;
 }
 
 .window-list-item-box:focus:hover  {
@@ -1730,7 +1734,7 @@ height of the table to be ICON_SIZE + IMAGE_SIZE + spacing-rows = 24 + 125 + 10 
 
 /* experimental support for grouped window list */
 .grouped-window-list-item-box {
-  color: #ffffff;
+  color: #000000;
   font-weight: normal;
   border-image: none;
   transition-duration: 100;
@@ -1756,6 +1760,7 @@ height of the table to be ICON_SIZE + IMAGE_SIZE + spacing-rows = 24 + 125 + 10 
 .grouped-window-list-item-box:focus {
   border-image: url("active.png") 8;
   transition-duration: 100;
+  color: #ffffff;
 }
 
 .grouped-window-list-item-box:focus:hover {


### PR DESCRIPTION
I have noticed that the foreground used on window list and grouped window list in cinnamon is kinda impossible to read using the homestead theme, then i decided to change the foreground to make it look like this. 
![image](https://github.com/user-attachments/assets/854f8f31-4654-4b91-b9b3-f8cb6b37e7c0)
